### PR TITLE
Enciv ssl

### DIFF
--- a/app/server/server.js
+++ b/app/server/server.js
@@ -191,7 +191,7 @@ class HttpServer extends EventEmitter {
         addWWW=true;
       }*/
       console.info("httpToHttps",req.secure, req.protocol, req.hostname);
-      if(!req.secure || addWWW){
+      if(!req.secure || req.protocol==='http'){
         console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + hostname + req.url)
         res.redirect('https://' + hostName + req.url);
       } else

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -190,6 +190,7 @@ class HttpServer extends EventEmitter {
         hostName=hostParts.join('.');
         addWWW=true;
       }*/
+      console.info("httpToHttps",req.secure, req.protocol, req.hostname);
       if(!req.secure || addWWW){
         console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + hostname + req.url)
         res.redirect('https://' + hostName + req.url);

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -193,7 +193,7 @@ class HttpServer extends EventEmitter {
       console.info("httpToHttps", req.secure, req.protocol, req.hostname);
       if ((!req.secure) || (req.protocol !== 'https')) {
         console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + req.hostname + req.url)
-        res.redirect('https://' + req.hostName + req.url);
+        res.redirect('https://' + req.hostname + req.url);
       } else
         next(); /* Continue to other routes if we're not redirecting */
     })

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -176,24 +176,24 @@ class HttpServer extends EventEmitter {
     this.getIota();
   }
 
-  httpToHttps(){
+  httpToHttps() {
     this.app.enable('trust proxy');
-    this.app.use((req,res,next) => {
-      let hostName=req.hostname;
-      if(hostName==='localhost') return next();
-      let hostParts=hostName.split('.');
-      if(hostParts.length===4 && hostParts[0]==='192' && hostParts[1]==='168') return next(); // it's coming from the lan
-      let addWWW=false;
+    this.app.use((req, res, next) => {
+      let hostName = req.hostname;
+      if (hostName === 'localhost') return next();
+      let hostParts = hostName.split('.');
+      if (hostParts.length === 4 && hostParts[0] === '192' && hostParts[1] === '168') return next(); // it's coming from the lan
+      let addWWW = false;
       /*
       if((hostParts.length && hostParts[1]!=="herokuapp") && (!hostParts.length || hostParts[0]!=='www')){
         hostParts.unshift("www");
         hostName=hostParts.join('.');
         addWWW=true;
       }*/
-      console.info("httpToHttps",req.secure, req.protocol, req.hostname);
-      if(!req.secure || req.protocol!=='https'){
-        console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + hostname + req.url)
-        res.redirect('https://' + hostName + req.url);
+      console.info("httpToHttps", req.secure, req.protocol, req.hostname);
+      if ((!req.secure) || (req.protocol !== 'https')) {
+        console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + req.hostname + req.url)
+        res.redirect('https://' + req.hostName + req.url);
       } else
         next(); /* Continue to other routes if we're not redirecting */
     })

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -191,7 +191,7 @@ class HttpServer extends EventEmitter {
         addWWW=true;
       }*/
       console.info("httpToHttps",req.secure, req.protocol, req.hostname);
-      if(!req.secure || req.protocol==='http'){
+      if(!req.secure || req.protocol!=='https'){
         console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + hostname + req.url)
         res.redirect('https://' + hostName + req.url);
       } else

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -184,13 +184,14 @@ class HttpServer extends EventEmitter {
       let hostParts=hostName.split('.');
       if(hostParts.length===4 && hostParts[0]==='192' && hostParts[1]==='168') return next(); // it's coming from the lan
       let addWWW=false;
+      /*
       if((hostParts.length && hostParts[1]!=="herokuapp") && (!hostParts.length || hostParts[0]!=='www')){
         hostParts.unshift("www");
         hostName=hostParts.join('.');
         addWWW=true;
-      }
+      }*/
       if(!req.secure || addWWW){
-        console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + req.hostname + req.url)
+        console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + hostname + req.url)
         res.redirect('https://' + hostName + req.url);
       } else
         next(); /* Continue to other routes if we're not redirecting */

--- a/app/server/server.js
+++ b/app/server/server.js
@@ -181,16 +181,6 @@ class HttpServer extends EventEmitter {
     this.app.use((req, res, next) => {
       let hostName = req.hostname;
       if (hostName === 'localhost') return next();
-      let hostParts = hostName.split('.');
-      if (hostParts.length === 4 && hostParts[0] === '192' && hostParts[1] === '168') return next(); // it's coming from the lan
-      let addWWW = false;
-      /*
-      if((hostParts.length && hostParts[1]!=="herokuapp") && (!hostParts.length || hostParts[0]!=='www')){
-        hostParts.unshift("www");
-        hostName=hostParts.join('.');
-        addWWW=true;
-      }*/
-      console.info("httpToHttps", req.secure, req.protocol, req.hostname);
       if ((!req.secure) || (req.protocol !== 'https')) {
         console.info("server.httpToHttps redirecting to ", req.secure, 'https://' + req.hostname + req.url)
         res.redirect('https://' + req.hostname + req.url);


### PR DESCRIPTION
This fixes the httpTohttps route so that it works when configured as a subdomain like cc.enciv.org.
