### PR TITLE
add stop recording button

### DIFF
--- a/app/components/web-components/undebate.jsx
+++ b/app/components/web-components/undebate.jsx
@@ -1806,10 +1806,6 @@ class RASPUndebate extends React.Component {
 
   stopRecording() {
     this.stopCountDown()
-    if (this.talkativeTimeout) {
-      clearTimeout(this.talkativeTimeout)
-      this.talkativeTimeout = 0
-    }
     this.camera && this.camera.stopRecording()
     this.setState({ isRecording: false })
   }
@@ -1950,6 +1946,10 @@ class RASPUndebate extends React.Component {
     if (this.recordTimeout) {
       clearTimeout(this.recordTimeout)
       this.recordTimeout = 0
+    }
+    if (this.talkativeTimeout) {
+      clearTimeout(this.talkativeTimeout)
+      this.talkativeTimeout = 0
     }
     if (this.setState.countDown > 0) this.setState({ countDown: 0 })
   }

--- a/app/components/web-components/undebate.jsx
+++ b/app/components/web-components/undebate.jsx
@@ -1637,6 +1637,10 @@ class RASPUndebate extends React.Component {
   ]
 
   allPause() {
+    if (this.state.isRecording) {
+      this.finishedSpeaking()
+      return
+    }
     if (!this.state.begin) {
       this.beginButton()
     } else if (!this.state.allPaused) {
@@ -1647,9 +1651,6 @@ class RASPUndebate extends React.Component {
     } else {
       this.allPlay()
       this.setState({ allPaused: false })
-    }
-    if (this.state.isRecording) {
-      this.stopRecording()
     }
   }
 

--- a/app/components/web-components/undebate.jsx
+++ b/app/components/web-components/undebate.jsx
@@ -1637,19 +1637,17 @@ class RASPUndebate extends React.Component {
   ]
 
   allPause() {
-    if (this.state.isRecording) {
-      this.finishedSpeaking()
-      return
-    }
     if (!this.state.begin) {
       this.beginButton()
     } else if (!this.state.allPaused) {
       Object.keys(this.participants).forEach(participant => {
         if (this[participant] && this[participant].current) this[participant].current.pause()
       })
+      if (this.state.isRecording) this.pauseRecording()
       this.setState({ allPaused: true })
     } else {
       this.allPlay()
+      if (this.rerecord) this.resumeRecording()
       this.setState({ allPaused: false })
     }
   }
@@ -1793,8 +1791,16 @@ class RASPUndebate extends React.Component {
 
   rerecordButton() {
     logger.info('Undebate.rerecordButton')
-    this.stopRecording() // it might be recording when the user hit's rerecord
+    this.pauseRecording() // it might be recording when the user hits rerecord
+    this.resumeRecording()
+  }
+
+  pauseRecording() {
+    this.stopRecording()
     this.rerecord = true
+  }
+
+  resumeRecording() {
     const { seatOffset, round } = this.state
     this.newOrder(seatOffset, round)
   }

--- a/app/components/web-components/undebate.jsx
+++ b/app/components/web-components/undebate.jsx
@@ -1799,9 +1799,9 @@ class RASPUndebate extends React.Component {
     this.newOrder(seatOffset, round)
   }
 
-  startRecording(cb) {
+  startRecording(cb, visible = false) {
     this.camera.startRecording(cb)
-    this.setState({ isRecording: true })
+    if (visible) this.setState({ isRecording: true })
   }
 
   stopRecording() {
@@ -1858,7 +1858,7 @@ class RASPUndebate extends React.Component {
               this.startCountDown(limit, () => this.autoNextSpeaker())
               this.talkativeTimeout = setTimeout(() => this.setState({ talkative: true }), limit * 0.75 * 1000)
               this.nextMediaState(participant)
-              this.startRecording(blobs => this.saveRecordingToParticipants(true, round, blobs))
+              this.startRecording(blobs => this.saveRecordingToParticipants(true, round, blobs), true)
             })
           }
         } else {

--- a/assets/svg/ICON_STOP.svg
+++ b/assets/svg/ICON_STOP.svg
@@ -1,0 +1,4 @@
+<svg width="65" height="65" viewBox="0 0 65 65" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="32.5" cy="32.5" r="32.5" fill="black"/>
+<rect x="22.5" y="22.5" width="20" height="20" stroke="white" stroke-width="2" />
+</svg>


### PR DESCRIPTION
Closes #74 

This adds a new Stop icon that gets conditionally rendered anytime the camera is actively recording. 

Here is a pic of what it looks like when recording:

![Screenshot 2020-03-19 17 39 14](https://user-images.githubusercontent.com/20749982/77127127-9fb5dd00-6a08-11ea-83c7-ee4a1151d364.png)

When you press the Stop button, the camera stops recording, and the play/pause button returns to normal use. To start recording again, the play/pause button won't do anything, you instead have to press the rerecord button. 

@epg323 and I worked on this together today via some pair programming for about 2 hours. 

I have only tested this on chrome!
