### PR TITLE
metaTags from iota.webComponent will be added to HTML

### DIFF
--- a/app/server/routes/server-react-render.jsx
+++ b/app/server/routes/server-react-render.jsx
@@ -55,8 +55,11 @@ function serverReactRender(req, res, next) {
                     <link rel="manifest"  href="/assets/images/site.webmanifest"/>
                     <link rel="shortcut icon" href="/assets/images/favicon.ico" />
                     <meta name="theme-color" content="#ffffff"/>
-
-
+                    ${(props.iota &&
+                      props.iota.webComponent &&
+                      props.iota.webComponent.metaTags &&
+                      props.iota.webComponent.metaTags.reduce((acc, meta) => acc + `<meta ${meta}>\n`, '')) ||
+                      ''}
                     <link href="https://fonts.googleapis.com/css?family=Montserrat&display=swap" rel="stylesheet">
                     <link href="https://fonts.googleapis.com/css?family=Libre+Franklin:400,800&display=swap" rel="stylesheet">
 


### PR DESCRIPTION
We can manually add metaTags to the webComponent in an iota - like this.  Have to generate the text and image manually. 
```
"webComponent": {
        "webComponent": "CandidateConversation",
        "logo": "undebate",
        "metaTags": [
            "property=\"og:title\" content=\"City of Onalaska Mayor\"",
            "property=\"og:image\" content=\"https://res.cloudinary.com/hf6mryjpf/image/upload/v1585862971/2020-04-02_11-40-42_ypcu5k.png\""
        ],
        "closing": {
            "thanks": "Thank You.",
            "iframe": {
                "src": "https://docs.google.com/forms/d/e/1FAIpQLSdupdesY-JhnhaB6rZn0-18VOMM3bkmrexrStPJ9-384NfqEg/viewform?embedded=true",
                "width": "640",
                "height": "2950"
            }
        },
```