### PR TITLE
Set max_old_space when node starts up - and Install.md updates

### DIFF
--- a/doc/Install.md
+++ b/doc/Install.md
@@ -38,18 +38,18 @@ Now lets get the environment variable with the URI for that database and store i
 
     echo "export MONGODB_URI="\"`heroku config:get MONGODB_URI -a undebate-something-unique`\" >> .bashrc
 
-Now we will add Cloudinary - a Content Delivery Network that has image and video manipulation features. A CDN gives you a place to store these things, and deliver them quickly over the internet. Your node server would be slower, and doesn't keep the files after the server restarts.
+Now we will add Cloudinary - a Content Delivery Network that has image and video manipulation features. A CDN gives you a place to store these things, and deliver them quickly over the internet. Your node server would be slower, and doesn't keep the files after the server restarts. In the text that follows, replace [something unique] with some name that you come up with, including the []'s for example undebate-banana
 
-    heroku addons:create cloudinary:starter -a undebate-something-unique
+    heroku addons:create cloudinary:starter -a undebate-[something unique]
 
 Again we get the environment variable with the URL for Cloudinary and store it in your config file for local use. There's a password in the string, so keep it secret.
 
-    echo "export CLOUDINARY_URL="\"`heroku config:get CLOUDINARY_URL -a undebate-something-unique`\" >> .bashrc
+    echo "export CLOUDINARY_URL="\"`heroku config:get CLOUDINARY_URL -a undebate-[something unique]`\" >> .bashrc
 
-Now we just tell node we are in development mode. Later we will set it to production
+Now we just tell node we are in development mode locally, but on heroku we set it to production. There are a few optimizations that are applied in production, and it's important to check to make sure it works that way.
 
     echo "export NODE_ENV=development" >> .bashrc
-    heroku config:set NODE_ENV=development
+    heroku config:set NODE_ENV=production
 
 Then to get all these environment variable set in your current instance of bash do this. But you won't have to it the next time you start up.
 
@@ -59,7 +59,7 @@ Now you should be able to run it.
 
     npm run dev
 
-You should now be able to browser to localhost:3011/schoolboard-conversation and see an undebate. The server is running locally on our machine. It's using webpack, which is really neat bacuase when you save changes to the source code, it will automatically be compliled and applied to the server and to the application in your browser. You may still have to refresh your browser page though.
+You should now be able to browser to localhost:3011/candidate-conversation and see an undebate. The server is running locally on our machine. It's using webpack, which is really neat bacuase when you save changes to the source code, it will automatically be compliled and applied to the server and to the application in your browser. You may still have to refresh your browser page though.
 
 You can use Control-C to terminate the server
 
@@ -67,9 +67,41 @@ To run this in the cloud on heroku:
 
     git push heroku HEAD:master
 
-Then you will be able to browse to `https://undebate-something-unique.herokuapp.com/schoolboard-conversation` and see the same thing.
+Then you will be able to browse to `https://undebate-[something unique].herokuapp.com/candidate-conversation` and see the same thing.
 
-Then, to record your own part in the schoolboard conversation browser to: localhost:3011/schoolboard-conversation-candidate-recorder or `https://undebate-something-unique.herokuapp.com/schoolboard-conversation-candidate-recorder`
+Then, to record your own part in the candidate conversation browser to: localhost:3011/candidateboard-conversation-candidate-recorder or `https://undebate-something-unique.herokuapp.com/schoolboard-conversation-candidate-recorder`
+
+There are other urls that you can check out in your development environment. To see the latest list do this:
+
+```
+cat iota.json || grep path
+```
+
+Here is the list as of the time of this writing:
+
+```
+    "path": "/candidate-conversation-5",
+    "path": "/candidate-conversation",
+    "path": "/candidate-conversation-candidate-recorder",
+    "path": "/candidate-conversation-candidate-recorder-sendinblue",
+    "path": "/candidate-conversation-candidate-recorder-with-email",
+    "path": "/what-is-democracy",
+    "path": "/youtube",
+    "path": "/hackforla-projects",
+    "path": "/hackforla-projects-recorder",
+    "path": "/schoolboard-undebate",
+    "path": "/schoolboard-undebate-candidate-recorder",
+    "path": "/candidate-conversation-2",
+    "path": "/candidate-conversation-3",
+    "path": "/candidate-conversation-4",
+    "path": "/candidate-conversation-6",
+    "path": "/candidate-conversation-7",
+    "path": "/test-join",
+    "path": "/iframe-demo",
+    "path": "/unpoll-demo"
+```
+
+Just take the url part, like "what-is-democracy" and add either localhost:3011 or https://undebate-[something unique].herokuapp.com at the beginning and you will be able to check it out.
 
 # Prettier
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Not debates, but a place where voters can get to know their candidates",
   "main": "dist/server/start.js",
   "scripts": {
-    "start": "node dist/server/start.js",
+    "start": "node --max_old_space_size=460 dist/server/start.js",
     "test": "jest",
     "test:coverage": "npm test -- --coverage",
     "test:watch": "npm test -- --watch",


### PR DESCRIPTION
If we don't set max_old_space when we startup on heroku, we get about 256MB of heap and then it crashes.  For a 512MB app, we need to set it to 460 according to heroku. 

Also updated Install.md to talk about the paths' that are available in the dev build.