### PR TITLE
Instruction link preamble

### DIFF
--- a/app/components/candidate-preamble.jsx
+++ b/app/components/candidate-preamble.jsx
@@ -31,7 +31,7 @@ candidate_questions=[
   ]
  */
 
-function CandidatePreamble({ onClick, agreed, bp_info, subject, candidate_questions }) {
+function CandidatePreamble({ onClick, agreed, bp_info, subject, candidate_questions, instructionLink }) {
   const classes = useStyles()
   const makeQuestions = (className, questions, keyIndex = 'mq') => {
     return (
@@ -93,6 +93,14 @@ function CandidatePreamble({ onClick, agreed, bp_info, subject, candidate_questi
             Or, hitting the <b>Hang Up</b> button or closing this window any time before hitting the <b>Post</b> button
             will cause any recordings to be discarded.
           </li>
+          {instructionLink && (
+            <li>
+              You can continue and each step will be explained one at a time, or you can review written instructions{' '}
+              <a target="#" href={instructionLink}>
+                here
+              </a>
+            </li>
+          )}
         </ul>
         <h2 style={{ marginBottom: '0.5rem' }}>Questions for Candidates</h2>
         {makeQuestions(
@@ -128,10 +136,10 @@ const useStyles = createUseStyles({
     },
   },
   PreambleList: {
-    paddingTop: '0.5em',
+    paddingTop: '0.4em',
     paddingLeft: '2em',
     '& li': {
-      paddingBottom: '0.5em',
+      paddingBottom: '0.4em',
     },
   },
   agreed: {},
@@ -149,7 +157,7 @@ const useStyles = createUseStyles({
     padding: '0',
     paddingLeft: '2em',
     '& li': {
-      paddingTop: '0.5em',
+      paddingTop: '0.4em',
     },
   },
   questionListInner: {

--- a/app/components/web-components/undebate.jsx
+++ b/app/components/web-components/undebate.jsx
@@ -41,6 +41,8 @@ import supportsVideoType from '../lib/supports-video-type'
 
 import { auto_quality, placeholder_image } from '../lib/cloudinary-urls'
 import createParticipant from '../lib/create-participant'
+import Modal from './Modal'
+import Icon from '../lib/icon'
 
 function promiseSleep(time) {
   return new Promise((ok, ko) => setTimeout(ok, time))
@@ -602,17 +604,12 @@ const styles = {
 }
 
 class Undebate extends React.Component {
-  render() {
-    return <RASPUndebate {...this.props} />
-  }
-}
-
-class RASPUndebate extends React.Component {
   static onYouTubeIframeAPIReadyList = []
   retries = {}
   requestPermissionElements = []
   preFetchList = []
   youtubePlayers = []
+  uploadStarted = false
   constructor(props) {
     super(props)
     if (typeof window !== 'undefined') {
@@ -731,6 +728,7 @@ class RASPUndebate extends React.Component {
     allPaused: true, // so the play button shows
     warmup: false,
     isRecording: false,
+    isPortraitPhoneRecording: false,
 
     seatStyle: {
       speaking: {
@@ -2105,6 +2103,9 @@ class RASPUndebate extends React.Component {
   }
 
   onUserUpload() {
+    if (this.uploadStarted) return
+    // prevent double uploads - the users might double click the upload button
+    else this.uploadStarted = true
     logger.info('Undebate.onUserUpload')
     logger.trace('onUserUpload', this.props)
     const userId = (this.props.user && this.props.user.id) || this.state.newUserId
@@ -2365,8 +2366,33 @@ class RASPUndebate extends React.Component {
     } else this.setState({ intro: true, stylesSet: true, allPaused: false }, () => this.onIntroEnd())
   }
 
+  renderPortraitRecordingWarning = (browserConfig, isRecording, isPortraitPhoneRecording) => {
+    let portraitMode = typeof window !== 'undefined' && window.innerWidth < window.innerHeight
+    if (browserConfig.type === 'phone' && !portraitMode && !isRecording && isPortraitPhoneRecording) {
+      this.setState({ isPortraitPhoneRecording: false })
+      this.resumeRecording()
+    } else if (browserConfig.type === 'phone' && portraitMode && isRecording) {
+      this.pauseRecording()
+      this.setState({ isPortraitPhoneRecording: true })
+    }
+  }
+
   render() {
-    const { className, classes, opening = {}, closing = { thanks: 'Thank You' }, bp_info = {} } = this.props
+    const {
+      className,
+      classes,
+      opening = {},
+      closing = { thanks: 'Thank You' },
+      bp_info = {},
+      instructionLink,
+      subject,
+      browserConfig,
+      participants,
+      user,
+      hangupButton = {},
+      logo,
+      path,
+    } = this.props
     const {
       round,
       finishUp,
@@ -2385,24 +2411,37 @@ class RASPUndebate extends React.Component {
       introStyle,
       stylesSet,
       conversationTopicStyle,
+      isRecording,
+      isPortraitPhoneRecording,
       reviewing,
+      uploadComplete,
+      hungUp,
+      preFetchQueue,
+      name,
+      firstName,
+      lastName,
+      newUserId,
+      progress,
+      fontSize,
+      stalled,
+      waitingPercent,
+      totalSize_before_hangup,
+      countDown,
+      errorMsg,
+      left,
+      preambleAgreed,
     } = this.state
+
+    // puts a stop to recording with the phone in a portrait orientation
+    this.renderPortraitRecordingWarning(browserConfig, isRecording, isPortraitPhoneRecording)
 
     const getIntroStyle = name =>
       Object.assign({}, stylesSet && { transition: IntroTransition }, introStyle[name], intro && introSeatStyle[name])
     const innerWidth = typeof window !== 'undefined' ? window.innerWidth : 1920
     const humanSpeaking = this.speakingNow() === 'human'
 
-    //const scrollableIframe=done && !this.state.hungUp && closing.iframe && (!this.participants.human || (this.participants.human && this.state.uploadComplete));
-    const scrollableIframe = done && this.props.participants.human
-    /*
-      (done &&
-        !this.state.hungUp &&
-        closing.iframe &&
-        (!this.participants.human || (this.participants.human && this.state.uploadComplete))) ||
-      (done && this.state.hungUp && closing.iframe && this.participants.human)
-*/
-    const bot = this.props.browserConfig.type === 'bot'
+    const scrollableIframe = done && participants.human
+    const bot = browserConfig.type === 'bot'
     const noOverlay = this.noOverlay
 
     if (this.canNotRecordHere || (this.camera && this.camera.canNotRecordHere)) {
@@ -2424,7 +2463,7 @@ class RASPUndebate extends React.Component {
       )
     }
     const recordingPlaceholderBar = () => {
-      if (this.props.participants.human) {
+      if (participants.human) {
         const { listeningRound, listeningSeat } = this.listening()
         if (listeningRound === round && listeningSeat === this.seatOfParticipant('human')) {
           const reviewingAndNotReRecording = reviewing && !this.rerecord
@@ -2444,27 +2483,25 @@ class RASPUndebate extends React.Component {
     }
 
     const surveyForm = () =>
-      (closing.iframe &&
-        (!this.participants.human || (this.participants.human && (this.state.uploadComplete || this.state.hungUp))) && (
-          <iframe
-            src={closing.iframe.src}
-            width={Math.min(closing.iframe.width, innerWidth)}
-            height={closing.iframe.height}
-            frameBorder="0"
-            marginHeight="0"
-            marginWidth="0"
-          >
-            Loading...
-          </iframe>
-        )) ||
-      (closing.link &&
-        (!this.participants.human || (this.participants.human && (this.state.uploadComplete || this.state.hungUp))) && (
-          <div className={classes['thanks-link']}>
-            <a href={closing.link.url} target={closing.link.target || '_self'}>
-              {closing.link.name}
-            </a>
-          </div>
-        ))
+      (closing.iframe && (!this.participants.human || (this.participants.human && (uploadComplete || hungUp))) && (
+        <iframe
+          src={closing.iframe.src}
+          width={Math.min(closing.iframe.width, innerWidth)}
+          height={closing.iframe.height}
+          frameBorder="0"
+          marginHeight="0"
+          marginWidth="0"
+        >
+          Loading...
+        </iframe>
+      )) ||
+      (closing.link && (!this.participants.human || (this.participants.human && (uploadComplete || hungUp))) && (
+        <div className={classes['thanks-link']}>
+          <a href={closing.link.url} target={closing.link.target || '_self'}>
+            {closing.link.name}
+          </a>
+        </div>
+      ))
     //! ===============================   beginOverlay   ===============================
     const beginOverlay = () =>
       !begin &&
@@ -2555,7 +2592,7 @@ class RASPUndebate extends React.Component {
               </div>
               <div>
                 <span className={cx(classes['thanks'], scrollableIframe && classes['scrollableIframe'])}>
-                  {this.state.preFetchQueue}
+                  {preFetchQueue}
                 </span>
               </div>
             </div>
@@ -2587,7 +2624,7 @@ class RASPUndebate extends React.Component {
 
     const reviewButton = () =>
       this.participants.human &&
-      !this.state.uploadComplete && (
+      !uploadComplete && (
         <div className={classes.reviewIt}>
           <button
             className={classes['beginButton']}
@@ -2614,22 +2651,19 @@ class RASPUndebate extends React.Component {
 
     const nameInput = () =>
       !bp_info.candidate_name &&
-      (this.state.newUserId || this.props.user) && (
+      (newUserId || user) && (
         <div style={{ display: 'flex', flexDirection: 'column' }}>
           <label style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
             Name Shown with Video
             <Input
-              className={this.props.classes['name']}
+              className={classes['name']}
               block
               medium
               required
               placeholder="Your Name Tag"
               ref="name"
               name="name"
-              defaultValue={
-                this.state.name ||
-                (this.state.firstName && this.state.lastName && this.state.firstName + ' ' + this.state.lastName)
-              }
+              defaultValue={name || (firstName && lastName && firstName + ' ' + lastName)}
               onChange={e => this.setState({ name: e.value })}
             />
           </label>
@@ -2639,26 +2673,26 @@ class RASPUndebate extends React.Component {
 
     const postButton = () =>
       this.participants.human &&
-      !this.state.uploadComplete && (
+      !uploadComplete && (
         <>
           <div>
             <button
-              disabled={this.newUser && !this.state.newUserId}
+              disabled={this.newUser && !newUserId}
               className={classes['beginButton']}
               onClick={this.onUserUpload.bind(this)}
             >
               Post
             </button>
           </div>
-          {this.state.progress && <div>{'uploading: ' + this.state.progress}</div>}
+          {progress && <div>{'uploading: ' + progress}</div>}
         </>
       )
 
     const authForm = () =>
       this.participants.human &&
-      !this.state.uploadComplete &&
+      !uploadComplete &&
       this.newUser &&
-      !this.state.newUserId && (
+      !newUserId && (
         <>
           <div style={{ textAlign: 'center' }}>
             <span>Join and your recorded videos will be uploaded and shared</span>
@@ -2666,9 +2700,9 @@ class RASPUndebate extends React.Component {
           <div style={{ display: 'flex', justifyContent: 'center' }}>
             <AuthForm
               userInfo={{
-                name: this.state.name || bp_info.candidate_name,
-                firstName: this.state.firstName || bp_info.first_name,
-                lastName: this.state.lastName || bp_info.last_name,
+                name: name || bp_info.candidate_name,
+                firstName: firstName || bp_info.first_name,
+                lastName: lastName || bp_info.last_name,
               }}
               onChange={this.onUserLogin.bind(this)}
             />
@@ -2678,7 +2712,7 @@ class RASPUndebate extends React.Component {
 
     const ending = () =>
       done &&
-      !this.state.hungUp && (
+      !hungUp && (
         <>
           <div className={cx(classes['outerBox'], scrollableIframe && classes['scrollableIframe'])} key="ending">
             <div style={{ width: '100%', height: '100%', display: 'table' }}>
@@ -2695,8 +2729,8 @@ class RASPUndebate extends React.Component {
         </>
       )
 
-    const hungUp = () =>
-      this.state.hungUp && (
+    const renderHungUp = () =>
+      hungUp && (
         <div className={cx(classes['outerBox'], scrollableIframe && classes['scrollableIframe'])} key="hungUp">
           <div style={{ width: '100%', height: '100%', display: 'table' }}>
             <div style={{ display: 'table-cell', verticalAlign: 'middle', textAlign: 'center' }}>
@@ -2717,10 +2751,9 @@ class RASPUndebate extends React.Component {
       let participant_name
       if (participant === 'human') {
         if (bp_info.candidate_name) participant_name = bp_info.candidate_name
-        else if (this.state.name) participant_name = this.state.name
-        else if (this.state.firstName || this.state.lastName)
-          participant_name = this.state.firstName + ' ' + this.state.lastName
-      } else participant_name = this.props.participants[participant].name
+        else if (name) participant_name = name
+        else if (firstName || lastName) participant_name = firstName + ' ' + lastName
+      } else participant_name = participants[participant].name
       /*src={"https://www.youtube.com/embed/"+getYouTubeID(this.participants[participant].listeningObjectURL)+"?enablejsapi=1&autoplay=1&loop=1&controls=0&disablekb=1&fs=0&modestbranding=1&rel=0"}*/
       return (
         <div
@@ -2737,10 +2770,10 @@ class RASPUndebate extends React.Component {
           {this.seat(i) === 'speaking' ? (
             <SocialShareBtn
               metaData={{
-                path: this.props.path,
-                subject: this.props.subject,
+                path: path,
+                subject: subject,
               }}
-              fontSize={this.state.fontSize}
+              fontSize={fontSize}
             />
           ) : null}
           <div
@@ -2809,7 +2842,7 @@ class RASPUndebate extends React.Component {
                 chair={chair}
               ></video>
               <div
-                className={cx(classes['stalledOverlay'], this.state.stalled === participant && classes['stalledNow'])}
+                className={cx(classes['stalledOverlay'], stalled === participant && classes['stalledNow'])}
                 style={{
                   width: (parseFloat(seatStyle[this.seat(i)].width) * innerWidth) / 100,
                   height: (parseFloat(seatStyle[this.seat(i)].width) * HDRatio * innerWidth) / 100,
@@ -2817,8 +2850,8 @@ class RASPUndebate extends React.Component {
               >
                 <div className={classes['stalledBox']}>
                   <p>Hmmmm... the Internet is slow here</p>
-                  <p>{`${this.props.participants[participant].name} will be with us shortly`}</p>
-                  <p>{`${this.state.waitingPercent}% complete`}</p>
+                  <p>{`${participants[participant].name} will be with us shortly`}</p>
+                  <p>{`${waitingPercent}% complete`}</p>
                 </div>
               </div>
             </>
@@ -2850,12 +2883,12 @@ class RASPUndebate extends React.Component {
           key={'agenda' + round + agendaStyle.left}
         >
           <div className={classes['innerAgenda']}>
-            {this.props.participants.moderator.agenda[round] && (
+            {participants.moderator.agenda[round] && (
               <>
                 <span className={classes['agendaTitle']}>Agenda</span>
                 <ul className={classes['agendaItem']}>
-                  {this.props.participants.moderator.agenda[round] &&
-                    this.props.participants.moderator.agenda[round].map((item, i) => <li key={item + i}>{item}</li>)}
+                  {participants.moderator.agenda[round] &&
+                    participants.moderator.agenda[round].map((item, i) => <li key={item + i}>{item}</li>)}
                 </ul>
               </>
             )}
@@ -2906,23 +2939,20 @@ class RASPUndebate extends React.Component {
         </div>
       )
 
-    const hangupButton = () =>
-      !this.state.hungUp &&
+    const renderHangupButton = () =>
+      !hungUp &&
       this.participants.human && (
         <div className={classes['hangUpButton']}>
           <button
             onClick={this.hangup}
             key="hangup"
-            title={
-              (this.props.hangupButton && this.props.hangupButton.title) ||
-              'Stop recording and delete all video stored in the browser.'
-            }
+            title={hangupButton.title || 'Stop recording and delete all video stored in the browser.'}
           >
-            {(this.props.hangupButton && this.props.hangupButton.name) || 'Hang Up'}
+            {hangupButton.name || 'Hang Up'}
           </button>
-          {this.state.totalSize_before_hangup && !this.state.uploadComplete ? (
+          {totalSize_before_hangup && !uploadComplete ? (
             <div className={classes['hangUpButtonReally']}>
-              {(this.props.hangupButton && this.props.hangupButton.question) ||
+              {hangupButton.question ||
                 'You have recorded video, did you really want to exit and delete it, rather than finish this and post it?'}
               <div
                 className={classes['hangUpButtonReallyClose']}
@@ -2938,14 +2968,14 @@ class RASPUndebate extends React.Component {
     const conversationTopic = topicStyle => {
       return (
         <>
-          {this.props.instructionLink && (
+          {instructionLink && (
             <div className={classes['instructionLink']}>
-              <a target="#" href={this.props.instructionLink}>
+              <a target="#" href={instructionLink}>
                 <i
                   className={cx('far', 'fa-question-circle', classes['instructionIcon'])}
                   onClick={() => {
                     this.ensurePaused()
-                    let win = window.open(this.props.instructionLink, '_blank')
+                    let win = window.open(instructionLink, '_blank')
                     win.focus()
                   }}
                 />
@@ -2953,22 +2983,21 @@ class RASPUndebate extends React.Component {
             </div>
           )}
           <div style={topicStyle} className={classes['conversationTopic']}>
-            <p className={classes['conversationTopicContent']}>{this.props.subject}</p>
+            <p className={classes['conversationTopicContent']}>{subject}</p>
           </div>
           <a target="#" href="https://www.EnCiv.org">
             <img className={classes['enciv-logo']} src="https://enciv.org/wp-content/uploads/2019/01/enciv-logo.png" />
           </a>
-          {this.props.logo && this.props.logo === 'undebate' ? (
+          {logo === 'undebate' ? (
             <a target="#" href="https://enciv.org/undebate">
               <img
                 className={classes['logo']}
                 src="https://res.cloudinary.com/hf6mryjpf/image/upload/c_scale,h_100/v1585602937/Undebate_Logo.png"
               />
             </a>
-          ) : this.props.logo && this.props.logo === 'none' ? (
+          ) : logo === 'none' ? (
             false
-          ) : (this.props.logo && this.props.logo === 'CandidateConversations') ||
-            typeof this.props.logo === 'undefined' ? (
+          ) : logo === 'CandidateConversations' || typeof logo === 'undefined' ? (
             <a target="#" href="https://ballotpedia.org/Candidate_Conversations">
               <img
                 className={classes['logo']}
@@ -2987,7 +3016,7 @@ class RASPUndebate extends React.Component {
         <>
           {conversationTopic(conversationTopicStyle)}
           <div className={classes['outerBox']}>
-            {Object.keys(this.props.participants).map((participant, i) => videoBox(participant, i, seatStyle))}
+            {Object.keys(participants).map((participant, i) => videoBox(participant, i, seatStyle))}
             {agenda(agendaStyle)}
           </div>
           <div
@@ -3000,55 +3029,66 @@ class RASPUndebate extends React.Component {
               warmup && classes['warmup']
             )}
           >
-            {(warmup ? '-' : '') + TimeFormat.fromS(Math.round(this.state.countDown), 'mm:ss')}
+            {(warmup ? '-' : '') + TimeFormat.fromS(Math.round(countDown), 'mm:ss')}
           </div>
           <div style={{ whiteSpace: 'pre-wrap' }}>
-            <span>{this.state.errorMsg}</span>
+            <span>{errorMsg}</span>
           </div>
         </>
       )
 
     return (
       <div
-        style={{ fontSize: this.state.fontSize }}
+        style={{ fontSize: fontSize }}
         className={cx(classes['wrapper'], scrollableIframe && classes['scrollableIframe'])}
       >
-        {this.props.participants.human && <ReactCameraRecorder ref={this.getCamera} />}
+        {isPortraitPhoneRecording ? (
+          <Modal
+            render={() => (
+              <>
+                <div>
+                  <Icon style={{ padding: '15% 0' }} icon={'redo'} flip={'horizontal'}></Icon>
+                </div>
+                Recording will start from the top after switching to landscape orientation
+              </>
+            )}
+          ></Modal>
+        ) : null}
+        {participants.human && <ReactCameraRecorder ref={this.getCamera} />}
         <section
           id="syn-ask-webrtc"
           key="began"
           className={cx(classes['innerWrapper'], scrollableIframe && classes['scrollableIframe'])}
-          style={{ left: this.state.left }}
+          style={{ left: left }}
           ref={this.calculatePositionAndStyle}
         >
           <audio ref={this.audio} playsInline controls={false} onEnded={this.audioEnd} key="audio"></audio>
           {main()}
-          {((this.participants.human && (this.state.preambleAgreed || opening.noPreamble)) ||
-            !this.participants.human) &&
+          {((this.participants.human && (preambleAgreed || opening.noPreamble)) || !this.participants.human) &&
             !bot &&
             beginOverlay()}
           {this.participants.human && !opening.noPreamble && !intro && !begin && !done && (
             <CandidatePreamble
-              subject={this.props.subject}
+              subject={subject}
               bp_info={bp_info}
-              agreed={this.state.preambleAgreed}
+              agreed={preambleAgreed}
               onClick={() => {
                 logger.info('Undebate preambleAgreed true')
                 this.setState({ preambleAgreed: true })
                 noOverlay && this.beginButton()
               }}
-              candidate_questions={this.props.participants.moderator.agenda}
+              candidate_questions={participants.moderator.agenda}
+              instructionLink={instructionLink}
             />
           )}
           {ending()}
-          {((this.participants.human && (this.state.preambleAgreed || opening.noPreamble)) ||
-            !this.participants.human) &&
+          {((this.participants.human && (preambleAgreed || opening.noPreamble)) || !this.participants.human) &&
             buttonBar(buttonBarStyle)}
           {recorderButtonBar(recorderButtonBarStyle)}
           {permissionOverlay()}
           {waitingOnModeratorOverlay()}
-          {hangupButton()}
-          {hungUp()}
+          {renderHangupButton()}
+          {renderHungUp()}
           {recordingPlaceholderBar()}
         </section>
       </div>

--- a/app/components/web-components/undebate.jsx
+++ b/app/components/web-components/undebate.jsx
@@ -41,8 +41,6 @@ import supportsVideoType from '../lib/supports-video-type'
 
 import { auto_quality, placeholder_image } from '../lib/cloudinary-urls'
 import createParticipant from '../lib/create-participant'
-import Modal from './Modal'
-import Icon from '../lib/icon'
 
 function promiseSleep(time) {
   return new Promise((ok, ko) => setTimeout(ok, time))
@@ -728,7 +726,6 @@ class Undebate extends React.Component {
     allPaused: true, // so the play button shows
     warmup: false,
     isRecording: false,
-    isPortraitPhoneRecording: false,
 
     seatStyle: {
       speaking: {
@@ -2366,17 +2363,6 @@ class Undebate extends React.Component {
     } else this.setState({ intro: true, stylesSet: true, allPaused: false }, () => this.onIntroEnd())
   }
 
-  renderPortraitRecordingWarning = (browserConfig, isRecording, isPortraitPhoneRecording) => {
-    let portraitMode = typeof window !== 'undefined' && window.innerWidth < window.innerHeight
-    if (browserConfig.type === 'phone' && !portraitMode && !isRecording && isPortraitPhoneRecording) {
-      this.setState({ isPortraitPhoneRecording: false })
-      this.resumeRecording()
-    } else if (browserConfig.type === 'phone' && portraitMode && isRecording) {
-      this.pauseRecording()
-      this.setState({ isPortraitPhoneRecording: true })
-    }
-  }
-
   render() {
     const {
       className,
@@ -2412,7 +2398,6 @@ class Undebate extends React.Component {
       stylesSet,
       conversationTopicStyle,
       isRecording,
-      isPortraitPhoneRecording,
       reviewing,
       uploadComplete,
       hungUp,
@@ -3042,18 +3027,6 @@ class Undebate extends React.Component {
         style={{ fontSize: fontSize }}
         className={cx(classes['wrapper'], scrollableIframe && classes['scrollableIframe'])}
       >
-        {isPortraitPhoneRecording ? (
-          <Modal
-            render={() => (
-              <>
-                <div>
-                  <Icon style={{ padding: '15% 0' }} icon={'redo'} flip={'horizontal'}></Icon>
-                </div>
-                Recording will start from the top after switching to landscape orientation
-              </>
-            )}
-          ></Modal>
-        ) : null}
         {participants.human && <ReactCameraRecorder ref={this.getCamera} />}
         <section
           id="syn-ask-webrtc"

--- a/iota.json
+++ b/iota.json
@@ -145,6 +145,7 @@
     },
     "webComponent": {
       "webComponent": "Undebate",
+      "instructionLink": "https://docs.google.com/document/d/1fORs9PlLss9azlsnf0A0lxFoOzDQJ9RJ-zNRZ583SVo/edit?usp=sharing",
       "participants": {},
       "opening": {
         "line1": "Thank you for helping us create a mock candidate conversation.",

--- a/iota.json
+++ b/iota.json
@@ -400,6 +400,15 @@
       "opening": {
         "noPreamble": true
       },
+      "logo": "none",
+      "instructionLink": "https://docs.google.com/document/d/1rTk1d7EP2SJxiXDJCG7opCO0-yNnVXhyiobwVoqo2is/edit?usp=sharing",
+      "metaTags": [
+        "property=\"og:title\" content=\"What is Democracy\"",
+        "property=\"og:image\" content=\"https://res.cloudinary.com/hf6mryjpf/image/upload/v1587412519/what-is-democracy-preview-2020Apr20_cl3ziv.png\""
+      ],
+      "hangupButton": {
+        "name": "Exit"
+      },
       "maxParticipants": 5,
       "webComponent": "Undebate",
       "participants": {


### PR DESCRIPTION
This adds a link to the preamble to the instructions, if there are instructions.  
![image](https://user-images.githubusercontent.com/3317487/83557474-9516ca00-a4c6-11ea-9da8-b9abfb348cd5.png)

After doing a lot of testing I decided to update the way that the coundown time worked, to skip the "0".  So it goes 3..2..1..15..14.. ...
I also made a tweak so that the time from 1 to 15 was 1 second rather than 1 second plus the transition time. 

added instuctionLink example to /candidate-conversation-candidate-recorder

also update the /what-is-democracy example to include the instructionLink and also the meta tags.

this also fixes a double pump problem where sometimes when someone posts a video, it gets posted twice.

and the props and state are listed out in render, to make it just a little bit easier to understand.
```
render() {
    const {
      className,
      classes,
      opening = {},
      closing = { thanks: 'Thank You' },
      bp_info = {},
      instructionLink,
      subject,
      browserConfig,
      participants,
      user,
      hangupButton = {},
      logo,
      path,
    } = this.props
    const {
      round,
      finishUp,
      done,
      begin,
      requestPermission,
      talkative,
      warmup,
      moderatorReadyToStart,
      intro,
      seatStyle,
      agendaStyle,
      buttonBarStyle,
      recorderButtonBarStyle,
      introSeatStyle,
      introStyle,
      stylesSet,
      conversationTopicStyle,
      isRecording,
      reviewing,
      uploadComplete,
      hungUp,
      preFetchQueue,
      name,
      firstName,
      lastName,
      newUserId,
      progress,
      fontSize,
      stalled,
      waitingPercent,
      totalSize_before_hangup,
      countDown,
      errorMsg,
      left,
      preambleAgreed,
    } = this.state
```
