### PR TITLE
No socket

### DIFF
--- a/app/client/main.js
+++ b/app/client/main.js
@@ -46,6 +46,8 @@ window.reactSetPath = path => {
 
 // process has to be defined before log4js is imported on the browser side.
 if (typeof window !== 'undefined') {
+  process.env.LOG4JS_CONFIG = { appenders: [] } // webpack doesn't initialize the socket logger right - so just prevent log4js from initializing loggers
+  var log4js = require('log4js')
   if (window.NoSocket) {
     log4js.configure({
       appenders: { bconsole: { type: bconsole }, socketlogger: { type: socketlogger } },
@@ -62,8 +64,6 @@ if (typeof window !== 'undefined') {
     )
     // if using web pack, this will be set on the browser. Dont' set it on the server
     __webpack_public_path__ = 'http://localhost:3011/assets/webpack/'
-    process.env.LOG4JS_CONFIG = { appenders: [] } // webpack doesn't initialize the socket logger right - so just prevent log4js from initializing loggers
-    var log4js = require('log4js')
     log4js.configure({
       appenders: { bconsole: { type: bconsole }, socketlogger: { type: socketlogger } },
       categories: {
@@ -72,9 +72,6 @@ if (typeof window !== 'undefined') {
       disableClustering: true,
     })
   } else {
-    //process.env.LOG4JS_CONFIG= {appenders: [{ type: 'bconsole' }, {type: 'socketlogger'}]};
-    process.env.LOG4JS_CONFIG = { appenders: [] } // webpack doesn't initialize the socket logger right - so just prevent log4js from initializing loggers
-    var log4js = require('log4js')
     log4js.configure({
       appenders: { bconsole: { type: bconsole } },
       categories: {

--- a/app/client/main.js
+++ b/app/client/main.js
@@ -31,13 +31,14 @@ if (!(location.hostname.startsWith('cc2020') || location.hostname.startsWith('un
     emit: (...args) => {
       console.error('emit was called with', ...args)
     },
+    NoSocket: true,
   }
 }
 
 // process has to be defined before log4js is imported on the browser side.
 process.env.LOG4JS_CONFIG = { appenders: [] } // webpack doesn't initialize the socket logger right - so just prevent log4js from initializing loggers
 var log4js = require('log4js')
-if (window.NoSocket) {
+if (window.socket.NoSocket) {
   log4js.configure({
     appenders: { bconsole: { type: bconsole } },
     categories: {

--- a/app/client/main.js
+++ b/app/client/main.js
@@ -50,9 +50,9 @@ if (typeof window !== 'undefined') {
   var log4js = require('log4js')
   if (window.NoSocket) {
     log4js.configure({
-      appenders: { bconsole: { type: bconsole }, socketlogger: { type: socketlogger } },
+      appenders: { bconsole: { type: bconsole } },
       categories: {
-        default: { appenders: ['bconsole', 'socketlogger'], level: window.env === 'production' ? 'info' : 'trace' },
+        default: { appenders: ['bconsole'], level: 'error' },
       },
       disableClustering: true,
     })
@@ -73,9 +73,9 @@ if (typeof window !== 'undefined') {
     })
   } else {
     log4js.configure({
-      appenders: { bconsole: { type: bconsole } },
+      appenders: { bconsole: { type: bconsole }, socketlogger: { type: socketlogger } },
       categories: {
-        default: { appenders: ['bconsole'], level: 'error' },
+        default: { appenders: ['bconsole', 'socketlogger'], level: window.env === 'production' ? 'info' : 'trace' },
       },
       disableClustering: true,
     })

--- a/app/components/site-feedback.jsx
+++ b/app/components/site-feedback.jsx
@@ -208,6 +208,7 @@ class SiteFeedback extends React.Component {
   //~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
   render() {
+    if (typeof window !== 'undefined' && window.socket.NoSocket) return null
     const { className, classes } = this.props
     let w,
       h,


### PR DESCRIPTION
When we are behind a reverse-proxy cache CDN socket.io won't work.  For that case, we disable socket io from the browser.  This is fine for viewers, but we will disable the SiteFeedback button.  For recorders, this is no good - so we won't direct recorders through the RPCCDN. 

