### PR TITLE
Mongo migrate

### DIFF
--- a/app/server/start.js
+++ b/app/server/start.js
@@ -54,10 +54,13 @@ async function asyncStart(emitter) {
       verbose = true
     }
 
-    if (!process.env.MONGODB_URI) {
-      throw new Error('Missing MONGODB_URI')
+    // heroku is going to delete the MONGODB_URI var on Nov10 - we need something else to use in the mean time
+    const MONGODB_URI = process.env.PRIMARYDB_URI || process.env.MONGODB_URI
+
+    if (!MONGODB_URI) {
+      throw new Error('Missing PRIMARYDB_URI or MONGODB_URI')
     }
-    await MongoModels.connect({ uri: process.env.MONGODB_URI }, {})
+    await MongoModels.connect({ uri: MONGODB_URI }, {})
     // any models that need to createIndexes will push their init function
     for await (const init of MongoModels.toInit) {
       await init()

--- a/app/tools/init-cap-logs.js
+++ b/app/tools/init-cap-logs.js
@@ -1,0 +1,46 @@
+'use strict'
+const MongoModels = require('mongo-models')
+const publicConfig = require('../../public.json')
+
+const Log = { collectionName: 'logs' } // to follow the format of a MongoModel
+async function main() {
+  try {
+    await MongoModels.connect({ uri: args.db }, { useUnifiedTopology: true })
+    // find out if the collection exists without creating the collection
+    var collections = await MongoModels.dbs['default'].listCollections({ name: Log.collectionName }).toArray()
+    if (collections && collections.length === 1) console.info('Log.init collection already exists')
+    console.info('Log.init creating collection')
+    var result = await MongoModels.dbs['default'].createCollection(Log.collectionName, {
+      capped: true,
+      size: publicConfig.MongoLogsCappedSize,
+    })
+    if (!result) console.error('Log.init result failed')
+    else console.info('succuess', result)
+    MongoModels.disconnect()
+  } catch (err) {
+    console.error('Log.init error:', err)
+    process.exit(1)
+  }
+}
+
+global.args = {
+  db: '',
+  fromPath: '',
+  toPath: '',
+}
+
+// fetch args from command line
+var argv = process.argv
+for (let arg = 2; arg < argv.length; arg++) {
+  if (typeof global.args[argv[arg]] !== 'undefined') global.args[argv[arg]] = argv[++arg]
+  else console.error('ignoring unexpected argument:', argv[arg])
+}
+
+;['db'].forEach(a => {
+  if (!args[a]) {
+    console.error(a, 'is required')
+    process.exit(1)
+  }
+})
+
+main()

--- a/public.json
+++ b/public.json
@@ -4,7 +4,7 @@
     "bigLimit": 20
   },
   "WebRTCMediaRecordPeriod": 100,
-  "MongoLogsCappedSize": 10485760,
+  "MongoLogsCappedSize": 104857600,
   "navigator batch size": 10,
   "sendEmailFrom": "no-reply@enciv.org",
   "sendFeedbackTo": "davidfridley@enciv.org",


### PR DESCRIPTION
When mlab goes away the MONGODB_URI env variable will be erased.  We need to have a secondary env variable PRIMARYDB_URI to fill its place.

Also crated a tool for setting the logs collection capped size, and changed the default capped size to 100Megs